### PR TITLE
Delete Modal

### DIFF
--- a/locales/en/plugin__console-plugin-template.json
+++ b/locales/en/plugin__console-plugin-template.json
@@ -17,5 +17,13 @@
   "Address": "Address",
   "Dashboard": "Dashboard",
   "Policies": "Policies",
-  "Policy Topology": "Policy Topology"
+  "Policy Topology": "Policy Topology",
+  "TLS": "TLS",
+  "Are you sure you want to delete the policy": "Are you sure you want to delete the policy",
+  "All Policies": "All Policies",
+  "DNS": "DNS",
+  "Auth": "Auth",
+  "RateLimit": "RateLimit",
+  "Edit": "Edit",
+  "Delete": "Delete"
 }

--- a/src/components/KuadrantPoliciesPage.tsx
+++ b/src/components/KuadrantPoliciesPage.tsx
@@ -168,6 +168,7 @@ const AllPoliciesTable: React.FC<AllPoliciesTableProps> = ({ data, unfilteredDat
 };
 
 const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
+  const { t } = useTranslation('plugin__console-plugin-template');
   const [isOpen, setIsOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
 
@@ -242,10 +243,10 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
       >
         <DropdownList>
           <DropdownItem value="edit" key="edit">
-            Edit
+            {t('Edit')}
           </DropdownItem>
           <DropdownItem value="delete" key="delete">
-            Delete
+          {t('Delete')}
           </DropdownItem>
         </DropdownList>
       </Dropdown>
@@ -255,10 +256,11 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
         onClose={() => setIsDeleteModalOpen(false)}
         aria-labelledby="delete-modal-title"
         aria-describedby="delete-modal-body"
+        variant="medium"
       >
         <ModalHeader title="Confirm Delete" />
         <ModalBody>
-          Are you sure you want to delete the resource {obj.metadata.name}?
+          {t("Are you sure you want to delete the policy")}: <b>{obj.metadata.name}</b>?
         </ModalBody>
         <ModalFooter>
           <Button key="confirm" variant={ButtonVariant.danger} onClick={onDeleteConfirm}>
@@ -425,7 +427,7 @@ const KuadrantPoliciesPage: React.FC = () => {
   let pages = [
     {
       href: '',
-      name: 'All Policies',
+      name: t('All Policies'),
       component: All
     }
   ];
@@ -438,12 +440,12 @@ const KuadrantPoliciesPage: React.FC = () => {
       ...pages,
       {
         href: 'dns',
-        name: 'DNS',
+        name: t('DNS'),
         component: DNS
       },
       {
         href: 'tls',
-        name: 'TLS',
+        name: t('TLS'),
         component: TLS
       }
     ];
@@ -452,12 +454,12 @@ const KuadrantPoliciesPage: React.FC = () => {
     ...pages,
     {
       href: 'auth',
-      name: 'Auth',
+      name: t('Auth'),
       component: Auth
     },
     {
       href: 'ratelimit',
-      name: 'RateLimit',
+      name: t('RateLimit'),
       component: RateLimit
     }
   ];


### PR DESCRIPTION
Implements https://github.com/Kuadrant/console-plugin/issues/16

- Added a delete action to the DropdownWithKebab
- Used some componentry from `@patternfly/react-core/next` for a new Modal
- Modal has a confirm action before delete
- Made some tweaks to `AllPoliciesListPage` - combined the `useK8sWatchResource` hooks into a single array mapping for sanity

Testing:

Create a test resource, for example a TLSPolicy:

```bash
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: jm-hypergateway
  namespace: jmadigan-test
spec:
  gatewayClassName: istio
  listeners:
  - allowedRoutes:
      namespaces:
        from: All
    name: api
    hostname: "*.jm.hcpapps.net"
    port: 443
    protocol: HTTPS
    tls:
      mode: Terminate
      certificateRefs:
        - name: apps-hcpapps-tls
          kind: Secret
EOF


kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1alpha1
kind: TLSPolicy
metadata:
  name: jm-hypergateway-tls-policy
  namespace: jmadigan-test
spec:
  targetRef:
    name: jm-hypergateway
    group: gateway.networking.k8s.io
    kind: Gateway
  issuerRef:
    group: cert-manager.io
    kind: ClusterIssuer
    name: not-found
EOF
```