### PR TITLE
Add RateLimitPolicy create page

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -41,6 +41,17 @@
     }
   },
   {
+    "type": "console.resource/create",
+    "properties": {
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1beta2",
+        "kind": "RateLimitPolicy"
+      },
+      "component": { "$codeRef": "KuadrantRateLimitPolicyCreatePage" }
+    }
+  },
+  {
     "type": "console.page/route",
     "properties": {
       "exact": true,

--- a/locales/en/plugin__console-plugin-template.json
+++ b/locales/en/plugin__console-plugin-template.json
@@ -56,5 +56,17 @@
   "Endpoint": "Endpoint",
   "Failure Threshold": "Failure Threshold",
   "Port": "Port",
-  "Protocol": "Protocol"
+  "Protocol": "Protocol",
+  "Add Limit": "Add Limit",
+  "Define Rate Limit": "Define Rate Limit",
+  "OK": "OK",
+  "Cancel": "Cancel",
+  "Error creating RateLimitPolicy": "Error creating RateLimitPolicy",
+  "Create RateLimitPolicy": "Create RateLimitPolicy",
+  "Limit Name is required!": "Limit Name is required!",
+  "No limits configured yet": "No limits configured yet",
+  "Configured Limits": "Configured Limits",
+  "Target reference type": "Target reference type",
+  "Unique name of the RateLimitPolicy": "Unique name of the RateLimitPolicy",
+  "RateLimitPolicy enables rate limiting for service workloads in a Gateway API network": "RateLimitPolicy enables rate limiting for service workloads in a Gateway API network"
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
       "PolicyTopologyPage": "./components/PolicyTopologyPage",
       "KuadrantPoliciesPage": "./components/KuadrantPoliciesPage",
       "KuadrantDNSPolicyCreatePage": "./components/KuadrantDNSPolicyCreatePage",
-      "KuadrantAuthPolicyCreatePage": "./components/KuadrantAuthPolicyCreatePage"
+      "KuadrantAuthPolicyCreatePage": "./components/KuadrantAuthPolicyCreatePage",
+      "KuadrantRateLimitPolicyCreatePage": "./components/KuadrantRateLimitPolicyCreatePage"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/src/components/KuadrantRateLimitPolicyCreatePage.tsx
+++ b/src/components/KuadrantRateLimitPolicyCreatePage.tsx
@@ -1,0 +1,358 @@
+import * as React from 'react';
+import Helmet from 'react-helmet';
+import {
+  PageSection,
+  Title,
+  TextInput,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Form,
+  Radio,
+  Button,
+  ButtonVariant,
+  Modal,
+  ActionGroup,
+  List,
+  ListItem,
+  Flex,
+  FlexItem,
+  Alert,
+} from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import './kuadrant.css';
+import { k8sCreate, ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { useHistory } from 'react-router-dom';
+import { LimitConfig, RateLimitPolicy } from './ratelimitpolicy/types'
+import getModelFromResource from '../utils/getModelFromResource';
+import { Gateway } from './gateway/types';
+import GatewaySelect from './gateway/GatewaySelect';
+import { ModalHeader, ModalBody, ModalFooter } from '@patternfly/react-core/next';
+import NamespaceSelect from './namespace/NamespaceSelect';
+import HTTPRouteSelect from './httproute/HTTPRouteSelect';
+import { HTTPRoute } from './httproute/types';
+import AddLimitModal from './ratelimitpolicy/AddLimitModal';
+
+const KuadrantRateLimitPolicyCreatePage: React.FC = () => {
+  const { t } = useTranslation('plugin__console-plugin-template');
+  const [createView, setCreateView] = React.useState<'form' | 'yaml'>('form');
+  const [policy, setPolicy] = React.useState('');
+  const [selectedNamespace, setSelectedNamespace] = React.useState('');
+  const [selectedGateway, setSelectedGateway] = React.useState<Gateway>({ name: '', namespace: '' });
+  const [selectedHTTPRoute, setSelectedHTTPRoute] = React.useState<HTTPRoute>({ name: '', namespace: '' });
+  const [targetType, setTargetType] = React.useState<'gateway' | 'httproute'>('gateway');
+
+  const [isAddLimitModalOpen, setIsAddLimitModalOpen] = React.useState(false);
+  const [isLimitNameAlertModalOpen, setIsLimitNameAlertModalOpen] = React.useState(false);
+
+  // State to hold all limit configurations
+  const [limits, setLimits] = React.useState<Record<string, LimitConfig>>({});
+
+  // State to hold the temporary limit being added
+  const [newLimit, setNewLimit] = React.useState<LimitConfig>({
+    rates: [{ duration: 60, limit: 100, unit: 'minute' }]
+  });
+  const [rateName, setRateName] = React.useState<string>('');
+
+  const handleOpenModal = () => {
+    // Reset temporary state when opening modal for new entry
+    setNewLimit({ rates: [{ duration: 60, limit: 100, unit: 'minute' }] });
+    setRateName('');
+    setIsAddLimitModalOpen(true);
+  };
+  const handleCloseModal = () => setIsAddLimitModalOpen(false);
+  const handleSave = () => {
+    if (!rateName) {
+      // Show alert modal if rateName is empty
+      setIsLimitNameAlertModalOpen(true);
+      return;
+    }
+
+    // Append the new limit to the list of limits
+    setLimits((prevLimits) => ({
+      ...prevLimits,
+      [rateName]: newLimit,
+    }));
+
+    // Close the modal after saving
+    handleCloseModal();
+  };
+
+
+  // Handle removing a limit by name
+  const handleRemoveLimit = (name: string) => {
+    setLimits((prevLimits) => {
+      const updatedLimits = { ...prevLimits };
+      delete updatedLimits[name];
+      return updatedLimits;
+    });
+  };
+
+  // Initialize the YAML resource object based on form state
+  const [yamlResource, setYamlResource] = React.useState(() => {
+    return {
+      apiVersion: 'kuadrant.io/v1beta2',
+      kind: 'RateLimitPolicy',
+      metadata: {
+        name: policy,
+        namespace: selectedNamespace,
+      },
+      spec: {
+        targetRef: {
+          group: 'gateway.networking.k8s.io',
+          kind: 'Gateway',
+          name: selectedGateway.name,
+          namespace: selectedGateway.namespace,
+        },
+        limits,
+      },
+    };
+  });
+
+  React.useEffect(() => {
+    const newTargetRef = targetType === 'gateway'
+      ? {
+        group: 'gateway.networking.k8s.io',
+        kind: 'Gateway',
+        name: selectedGateway.name,
+        namespace: selectedGateway.namespace,
+      }
+      : {
+        group: 'gateway.networking.k8s.io',
+        kind: 'HTTPRoute',
+        name: selectedHTTPRoute.name,
+        namespace: selectedHTTPRoute.namespace,
+      };
+    setYamlResource((prevResource) => ({
+      ...prevResource,
+      spec: {
+        ...prevResource.spec,
+        targetRef: newTargetRef,
+        limits,
+      },
+    }));
+  }, [targetType, selectedGateway, selectedHTTPRoute]);
+
+  const history = useHistory();
+
+  React.useEffect(() => {
+    const updatedYamlResource = {
+      apiVersion: 'kuadrant.io/v1beta2',
+      kind: 'RateLimitPolicy',
+      metadata: {
+        name: policy,
+        namespace: selectedNamespace,
+      },
+      spec: {
+        targetRef: {
+          group: 'gateway.networking.k8s.io',
+          kind: 'Gateway',
+          name: selectedGateway.name,
+          namespace: selectedGateway.namespace,
+        },
+        limits: { ...limits },
+      },
+    };
+
+    setYamlResource(updatedYamlResource);
+  }, [policy, selectedNamespace, selectedGateway, limits]);
+
+  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
+  const [errorModalMsg, setErrorModalMsg] = React.useState('')
+
+  const handleCreateViewChange = (value: 'form' | 'yaml') => {
+    setCreateView(value);
+  };
+
+  const handlePolicyChange = (_event, policy: string) => {
+    setPolicy(policy);
+  };
+
+  const handleSubmit = async () => {
+    const ratelimitPolicy: RateLimitPolicy = {
+      apiVersion: 'kuadrant.io/v1beta2',
+      kind: 'RateLimitPolicy',
+      metadata: {
+        name: policy,
+        namespace: selectedNamespace,
+      },
+      spec: {
+        targetRef: {
+          group: 'gateway.networking.k8s.io',
+          kind: 'Gateway',
+          name: selectedGateway.name,
+          namespace: selectedGateway.namespace
+        },
+      },
+    };
+
+    try {
+      await k8sCreate({
+        model: getModelFromResource(ratelimitPolicy),
+        data: ratelimitPolicy,
+        ns: selectedNamespace,
+      });
+      history.push('/kuadrant/all-namespaces/policies/ratelimit'); // Navigate after successful creation
+    } catch (error) {
+      console.error(t('Error creating RateLimitPolicy'), error);
+      setErrorModalMsg(error)
+      setIsErrorModalOpen(true)
+    }
+  };
+
+  const handleCancel = () => {
+    history.push('/kuadrant/all-namespaces/policies');
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title data-test="example-page-title">{t('Create RateLimitPolicy')}</title>
+      </Helmet>
+      <PageSection className='pf-m-no-padding'>
+        <div className='co-m-nav-title'>
+          <Title headingLevel="h1">{t('Create RateLimitPolicy')}</Title>
+          <p className='help-block co-m-pane__heading-help-text'>
+            <div>{t('RateLimitPolicy enables rate limiting for service workloads in a Gateway API network')}</div>
+          </p>
+        </div>
+        <FormGroup className="kuadrant-editor-toggle" role="radiogroup" isInline hasNoPaddingTop fieldId="create-type-radio-group" label="Create via:">
+          <Radio
+            name="create-type-radio"
+            label="Form"
+            id="create-type-radio-form"
+            isChecked={createView === 'form'}
+            onChange={() => handleCreateViewChange('form')}
+          />
+          <Radio
+            name="create-type-radio"
+            label="YAML"
+            id="create-type-radio-yaml"
+            isChecked={createView === 'yaml'}
+            onChange={() => handleCreateViewChange('yaml')}
+          />
+        </FormGroup>
+      </PageSection>
+      {createView === 'form' ? (
+        <PageSection>
+          <Form className='co-m-pane__form'>
+            <div>
+              <FormGroup label={t('Policy Name')} isRequired fieldId="policy-name">
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="policy-name"
+                  name="policy-name"
+                  value={policy}
+                  onChange={handlePolicyChange}
+                />
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem>{t('Unique name of the RateLimitPolicy')}</HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              </FormGroup>
+              <NamespaceSelect selectedNamespace={selectedNamespace} onChange={setSelectedNamespace} />
+              <FormGroup role="radiogroup" isInline fieldId='target-type' label={t('Target reference type')} isRequired aria-labelledby="target-type-label">
+                <Radio name='target-type' label='Gateway' id='target-type-gateway' isChecked={targetType === 'gateway'} onChange={() => setTargetType('gateway')} />
+                <Radio name='target-type' label='HTTPRoute' id='target-type-httproute' isChecked={targetType === 'httproute'} onChange={() => setTargetType('httproute')} />
+              </FormGroup>
+              <div className="pf-u-ml-md">
+                {targetType === 'gateway' ? (
+                  <GatewaySelect selectedGateway={selectedGateway} onChange={setSelectedGateway} />
+                ) : (
+                  <HTTPRouteSelect selectedHTTPRoute={selectedHTTPRoute} onChange={setSelectedHTTPRoute} />
+                )}
+              </div>
+              {/* Display the list of added limits */}
+              <FormGroup>
+                <Title headingLevel="h2" size="lg" style={{ marginTop: '20px' }}>{t('Configured Limits')}</Title>
+                <List>
+                  {Object.keys(limits).length > 0 ? (
+                    Object.entries(limits).map(([name, limitConfig], index) => (
+                      <ListItem key={index}>
+                        <Flex>
+                          <FlexItem>
+                            <strong>{name}</strong>: {limitConfig.rates?.[0]?.limit} requests per {limitConfig.rates?.[0]?.duration} {limitConfig.rates?.[0]?.unit}(s)
+                          </FlexItem>
+                          <FlexItem>
+                            {/* Button to remove a limit */}
+                            <Button variant="danger" onClick={() => handleRemoveLimit(name)}>
+                              {t('Remove Limit')}
+                            </Button>
+                          </FlexItem>
+                        </Flex>
+                      </ListItem>
+                    ))
+                  ) : (
+                    <ListItem>{t('No limits configured yet')}</ListItem>
+                  )}
+                </List>
+                <Button variant="primary" onClick={handleOpenModal}>
+                  {t('Add Limit')}
+                </Button>
+              </FormGroup>
+              {/* Modal to add a new limit */}
+              <AddLimitModal
+                isOpen={isAddLimitModalOpen}
+                onClose={handleCloseModal}
+                newLimit={newLimit}
+                setNewLimit={setNewLimit}
+                rateName={rateName}
+                setRateName={setRateName}
+                handleSave={handleSave}
+              />
+              <Modal
+                title="Validation Error"
+                isOpen={isLimitNameAlertModalOpen}
+                onClose={() => setIsLimitNameAlertModalOpen(false)}
+                variant="small"
+                aria-label="Rate Name is required error"
+              >
+                <p>{t('Limit Name is required!')}</p>
+                <Button variant="primary" onClick={() => setIsLimitNameAlertModalOpen(false)}>
+                  {t('OK')}
+                </Button>
+              </Modal>
+            </div>
+            <Alert
+              variant="info"
+              isInline
+              title="To set defaults, overrides, and more complex limits, use the YAML view."
+            />
+            <ActionGroup>
+              <Button variant={ButtonVariant.primary} onClick={handleSubmit}>
+                {t('Create RateLimitPolicy')}
+              </Button>
+              <Button variant={ButtonVariant.secondary} onClick={handleCancel}>
+                {t('Cancel')}
+              </Button>
+            </ActionGroup>
+          </Form>
+        </PageSection>
+      ) : (
+        <ResourceYAMLEditor initialResource={yamlResource} create />
+      )}
+      <Modal
+        isOpen={isErrorModalOpen}
+        onClose={() => setIsErrorModalOpen(false)}
+        aria-labelledby="error-modal-title"
+        aria-describedby="error-modal-body"
+        variant="medium"
+      >
+        <ModalHeader title={t('Error creating RateLimitPolicy')} />
+        <ModalBody>
+          <b>{errorModalMsg}</b>
+        </ModalBody>
+        <ModalFooter>
+          <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
+            {t('OK')}
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
+};
+
+export default KuadrantRateLimitPolicyCreatePage;

--- a/src/components/httproute/HTTPRouteSelect.tsx
+++ b/src/components/httproute/HTTPRouteSelect.tsx
@@ -1,0 +1,73 @@
+import { ResourceLink, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { FormGroup, FormHelperText, FormSelect, FormSelectOption, HelperText, HelperTextItem } from '@patternfly/react-core';
+import * as React from 'react';
+import { HTTPRoute } from './types'; // You will need to define this type similarly to Gateway.
+import { useTranslation } from 'react-i18next';
+
+interface HTTPRouteSelectProps {
+  selectedHTTPRoute: HTTPRoute,
+  onChange: (updated: HTTPRoute) => void;
+}
+
+const HTTPRouteSelect: React.FC<HTTPRouteSelectProps> = ({ selectedHTTPRoute, onChange }) => {
+  const { t } = useTranslation('plugin__console-plugin-template');
+  const [httpRoutes, setHTTPRoutes] = React.useState([]);
+  const gvk = { group: 'gateway.networking.k8s.io', version: 'v1', kind: 'HTTPRoute' };
+
+  const httpRouteResource = {
+    groupVersionKind: gvk,
+    isList: true
+  };
+
+  const [httpRouteData, httpRouteLoaded, httpRouteError] = useK8sWatchResource(httpRouteResource);
+
+  React.useEffect(() => {
+    if (httpRouteLoaded && !httpRouteError && Array.isArray(httpRouteData)) {
+      setHTTPRoutes(httpRouteData.map((httpRoute) => ({
+        name: httpRoute.metadata.name,
+        namespace: httpRoute.metadata.namespace,
+      })));
+    }
+  }, [httpRouteData, httpRouteLoaded, httpRouteError]);
+
+  const handleHTTPRouteChange = (event: React.FormEvent<HTMLSelectElement>) => {
+    const [namespace, name] = event.currentTarget.value.split('/');
+    onChange({ ...selectedHTTPRoute, name, namespace });
+  };
+
+  return (
+    <>
+      <FormGroup label={t('HTTPRoute API Target Reference')} isRequired fieldId="httproute-select">
+        <FormSelect
+          id="httproute-select"
+          value={`${selectedHTTPRoute.namespace}/${selectedHTTPRoute.name}`}
+          onChange={handleHTTPRouteChange}
+          aria-label={t('Select HTTPRoute')}
+        >
+          <FormSelectOption key="placeholder" value="" label={t('Select an HTTPRoute')} isPlaceholder />
+          {httpRoutes.map((httpRoute, index) => (
+            <FormSelectOption
+              key={index}
+              value={`${httpRoute.namespace}/${httpRoute.name}`}
+              label={`${httpRoute.namespace}/${httpRoute.name}`}
+            />
+          ))}
+        </FormSelect>
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>{t('You can view and create HTTPRoutes')} <ResourceLink
+              groupVersionKind={gvk}
+              title="Create an HTTPRoute"
+              hideIcon={true}
+              inline={true}
+              displayName="here"
+            />
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+    </>
+  );
+};
+
+export default HTTPRouteSelect;

--- a/src/components/httproute/types.ts
+++ b/src/components/httproute/types.ts
@@ -1,0 +1,4 @@
+export interface HTTPRoute {
+    name: string,
+    namespace: string
+}

--- a/src/components/kuadrant.css
+++ b/src/components/kuadrant.css
@@ -39,3 +39,10 @@
 .kuadrant-editor-toggle .pf-v5-c-radio {
   padding: 0 0 0 1rem;
 }
+
+.kuadrant-modal-dynamic-height {
+  min-height: auto;
+  max-height: 450px;
+  overflow-y: auto;
+  padding: 1rem;
+}

--- a/src/components/ratelimitpolicy/AddLimitModal.tsx
+++ b/src/components/ratelimitpolicy/AddLimitModal.tsx
@@ -1,0 +1,97 @@
+import { FormGroup, FormSelect, FormSelectOption, Modal, TextInput, Wizard, WizardStep } from '@patternfly/react-core';
+import * as React from 'react';
+import { LimitConfig } from './types';
+import { useTranslation } from 'react-i18next';
+
+const LimitConfigForm: React.FC<{
+  newLimit: LimitConfig;
+  setNewLimit: (limit: LimitConfig) => void;
+  rateName: string;
+  setRateName: (name: string) => void;
+}> = ({ newLimit, setNewLimit, rateName, setRateName }) => {
+  const { t } = useTranslation('plugin__console-plugin-template');
+  return (
+    <>
+      <FormGroup label={t('Limit Name')} fieldId="limit-name">
+        <TextInput
+          value={rateName}
+          onChange={(event) => setRateName(event.currentTarget.value)}
+          isRequired
+        />
+      </FormGroup>
+      <FormGroup label={t('Limit')} fieldId="limit">
+        <TextInput
+          type="number"
+          value={newLimit.rates?.[0]?.limit || ''}
+          onChange={(event) => setNewLimit({
+            ...newLimit,
+            rates: [{ ...newLimit.rates?.[0], limit: parseInt(event.currentTarget.value, 10) }]
+          })}
+          isRequired
+        />
+      </FormGroup>
+      <FormGroup label={t('Duration')} fieldId="duration">
+        <TextInput
+          type="number"
+          value={newLimit.rates?.[0]?.duration || ''}
+          onChange={(event) => setNewLimit({
+            ...newLimit,
+            rates: [{ ...newLimit.rates?.[0], duration: parseInt(event.currentTarget.value, 10) }]
+          })}
+          isRequired
+        />
+      </FormGroup>
+      <FormGroup label={t('Unit')} fieldId="unit">
+        <FormSelect
+          value={newLimit.rates?.[0]?.unit || 'second'}
+          onChange={(event) => setNewLimit({ ...newLimit, rates: [{ ...newLimit.rates?.[0], unit: event.currentTarget.value as "second" | "minute" | "hour" | "day" }] })}
+        >
+          <FormSelectOption value="second" label="Second" />
+          <FormSelectOption value="minute" label="Minute" />
+          <FormSelectOption value="hour" label="Hour" />
+          <FormSelectOption value="day" label="Day" />
+        </FormSelect>
+      </FormGroup>
+    </>
+  );
+};
+
+const AddLimitModal: React.FC<{
+  isOpen: boolean;
+  onClose: () => void;
+  newLimit: LimitConfig;
+  setNewLimit: (limit: LimitConfig) => void;
+  rateName: string;
+  setRateName: (name: string) => void;
+  handleSave: () => void;
+}> = ({ isOpen, onClose, newLimit, setNewLimit, rateName, setRateName, handleSave }) => {
+  const { t } = useTranslation('plugin__console-plugin-template');
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('Add Limit')}
+      width="50%"
+      hasNoBodyWrapper
+    >
+      <div className='kuadrant-modal-dynamic-height'>
+        <Wizard
+          height={400}
+          onSave={handleSave}
+          onClose={onClose}
+        >
+          <WizardStep name={t('Define Rate Limit')} id="define-rate-limit" footer={{ nextButtonText: t('Add Limit'), isBackHidden: true }}>
+            <LimitConfigForm
+              newLimit={newLimit}
+              setNewLimit={setNewLimit}
+              rateName={rateName}
+              setRateName={setRateName}
+            />
+          </WizardStep>
+        </Wizard>
+      </div>
+    </Modal>
+  );
+};
+
+export default AddLimitModal;

--- a/src/components/ratelimitpolicy/types.ts
+++ b/src/components/ratelimitpolicy/types.ts
@@ -1,0 +1,83 @@
+export interface RateLimitPolicy {
+  apiVersion: string;
+  kind: string;
+  metadata: Record<string, any>;
+  spec: {
+    defaults?: {
+      limits?: {
+        [key: string]: LimitConfig;
+      };
+    };
+    limits?: {
+      [key: string]: LimitConfig;
+    };
+    overrides?: {
+      limits?: {
+        [key: string]: LimitConfig;
+      };
+    };
+    targetRef: TargetRef;
+  }
+}
+
+export interface LimitConfig {
+  counters?: ContextSelector[];
+  rates?: Rate[];
+  routeSelectors?: RouteSelector[];
+  when?: Condition[];
+}
+
+export interface ContextSelector {
+  // ContextSelector is based on a dot-separated path, e.g., 'request.path'
+  [key: string]: string;
+}
+
+export interface Rate {
+  duration: number; // Time period for the rate limit
+  limit: number;    // Max value allowed in the time period
+  unit: 'second' | 'minute' | 'hour' | 'day'; // Time unit for the limit
+}
+
+export interface RouteSelector {
+  hostnames?: string[]; // Hostnames for the route
+  matches?: HTTPRouteMatch[];
+}
+
+export interface HTTPRouteMatch {
+  headers?: HTTPHeaderMatch[];
+  method?: HTTPMethod;
+  path?: HTTPPathMatch;
+  queryParams?: HTTPQueryParamMatch[];
+}
+
+export interface HTTPHeaderMatch {
+  name: string; // Name of the header (case-insensitive)
+  value: string; // Value of the header to match
+  type?: 'Exact' | 'RegularExpression'; // How to match the header value
+}
+
+export type HTTPMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';
+
+export interface HTTPPathMatch {
+  type: 'Exact' | 'PathPrefix' | 'RegularExpression'; // How to match the path
+  value: string; // The value of the path to match
+}
+
+export interface HTTPQueryParamMatch {
+  name: string; // Name of the query parameter
+  value: string; // Value of the query parameter
+  type?: 'Exact' | 'RegularExpression'; // How to match the query parameter value
+}
+
+export interface Condition {
+  operator: 'eq' | 'neq' | 'startswith' | 'endswith' | 'incl' | 'excl' | 'matches'; // Operator for comparison
+  selector: string; // Well-known selector (e.g., request.path)
+  value: string; // The value for comparison
+}
+
+export interface TargetRef {
+  group: string;
+  kind: 'HTTPRoute' | 'Gateway'; // Supported values
+  name: string;
+  namespace: string;
+}


### PR DESCRIPTION
Closes #31 

Screenshots below.
A few fields have been purposefully left out of the form view as the API will be changing for kuadrant v1.
Future changes to the from are captured in https://github.com/Kuadrant/console-plugin/issues/68
In the interim, an info message is shown to direct the user to the yaml view for more complex limits configuration beyond simple limits.

### Create form

![image](https://github.com/user-attachments/assets/168af572-7575-4ab4-be39-9c3e0e8ed0cc)

### Add Limit modal

![image](https://github.com/user-attachments/assets/74079de3-eb85-4ecc-9ac8-8bb132dfc61d)

### Limits in form

![image](https://github.com/user-attachments/assets/6913a0ef-a45f-41d2-96ef-1416e912c538)

### Yaml editor

![image](https://github.com/user-attachments/assets/c40d11d3-80af-4688-b493-bc3339d9e305)
