### PR TITLE
Move Limit selector out to separate component

### DIFF
--- a/src/components/kuadrant.css
+++ b/src/components/kuadrant.css
@@ -108,3 +108,11 @@
   margin-left: 1rem;
   margin-right: 1rem
 }
+
+.kuadrant-limits-header {
+  margin: 1rem 0 0;
+}
+
+.kuadrant-limits-button, .pf-v5-c-label-group {
+  margin: 1rem;
+}

--- a/src/components/ratelimitpolicy/LimitSelect.tsx
+++ b/src/components/ratelimitpolicy/LimitSelect.tsx
@@ -1,0 +1,110 @@
+import { FormGroup, Title, List, ListItem, Flex, FlexItem, Button, Modal } from "@patternfly/react-core";
+import * as React from "react";
+import AddLimitModal from "./AddLimitModal";
+import { LimitConfig } from "./types";
+import { useTranslation } from "react-i18next";
+
+interface LimitSelectProps {
+  limits: Record<string, LimitConfig>;
+  setLimits: React.Dispatch<React.SetStateAction<Record<string, LimitConfig>>>;
+}
+
+const LimitSelect: React.FC<LimitSelectProps> = ({ limits, setLimits }) => {
+  const { t } = useTranslation('plugin__console-plugin-template');
+  const [isAddLimitModalOpen, setIsAddLimitModalOpen] = React.useState(false);
+  const [isLimitNameAlertModalOpen, setIsLimitNameAlertModalOpen] = React.useState(false);
+  // State to hold the temporary limit being added
+  const [newLimit, setNewLimit] = React.useState<LimitConfig>({
+    rates: [{ duration: 60, limit: 100, unit: 'minute' }]
+  });
+  const [rateName, setRateName] = React.useState<string>('');
+  const handleOpenModal = () => {
+    // Reset temporary state when opening modal for new entry
+    setNewLimit({ rates: [{ duration: 60, limit: 100, unit: 'minute' }] });
+    setRateName('');
+    setIsAddLimitModalOpen(true);
+  };
+  const handleCloseModal = () => setIsAddLimitModalOpen(false);
+
+  const onAddLimit = () => {
+    if (!rateName) {
+      // Show alert modal if rateName is empty
+      setIsLimitNameAlertModalOpen(true);
+      return;
+    }
+
+    // Append the new limit to the list of limits
+    setLimits((prevLimits) => ({
+      ...prevLimits,
+      [rateName]: newLimit,
+    }));
+
+    // Close the modal after saving
+    handleCloseModal();
+  };
+
+  // Handle removing a limit by name
+  const handleRemoveLimit = (name: string) => {
+    setLimits((prevLimits) => {
+      const updatedLimits = { ...prevLimits };
+      delete updatedLimits[name];
+      return updatedLimits;
+    });
+  };
+
+  return (
+    <>
+      <FormGroup>
+        <Title headingLevel="h2" size="lg" style={{ marginTop: '20px' }}>{t('Configured Limits')}</Title>
+        <List>
+          {Object.keys(limits).length > 0 ? (
+            Object.entries(limits).map(([name, limitConfig], index) => (
+              <ListItem key={index}>
+                <Flex>
+                  <FlexItem>
+                    <strong>{name}</strong>: {limitConfig.rates?.[0]?.limit} requests per {limitConfig.rates?.[0]?.duration} {limitConfig.rates?.[0]?.unit}(s)
+                  </FlexItem>
+                  <FlexItem>
+                    {/* Button to remove a limit */}
+                    <Button variant="danger" onClick={() => handleRemoveLimit(name)}>
+                      {t('Remove Limit')}
+                    </Button>
+                  </FlexItem>
+                </Flex>
+              </ListItem>
+            ))
+          ) : (
+            <ListItem>{t('No limits configured yet')}</ListItem>
+          )}
+        </List>
+        <Button variant="primary" onClick={handleOpenModal}>
+          {t('Add Limit')}
+        </Button>
+      </FormGroup>
+      {/* Modal to add a new limit */}
+      <AddLimitModal
+        isOpen={isAddLimitModalOpen}
+        onClose={handleCloseModal}
+        newLimit={newLimit}
+        setNewLimit={setNewLimit}
+        rateName={rateName}
+        setRateName={setRateName}
+        handleSave={onAddLimit}
+      />
+      <Modal
+        title="Validation Error"
+        isOpen={isLimitNameAlertModalOpen}
+        onClose={() => setIsLimitNameAlertModalOpen(false)}
+        variant="small"
+        aria-label="Rate Name is required error"
+      >
+        <p>{t('Limit Name is required!')}</p>
+        <Button variant="primary" onClick={() => setIsLimitNameAlertModalOpen(false)}>
+          {t('OK')}
+        </Button>
+      </Modal>
+    </>
+  );
+};
+
+export default LimitSelect;

--- a/src/components/ratelimitpolicy/LimitSelect.tsx
+++ b/src/components/ratelimitpolicy/LimitSelect.tsx
@@ -1,4 +1,4 @@
-import { FormGroup, Title, List, ListItem, Flex, FlexItem, Button, Modal } from "@patternfly/react-core";
+import { FormGroup, Title, Button, Modal, Label, LabelGroup } from "@patternfly/react-core";
 import * as React from "react";
 import AddLimitModal from "./AddLimitModal";
 import { LimitConfig } from "./types";
@@ -13,37 +13,33 @@ const LimitSelect: React.FC<LimitSelectProps> = ({ limits, setLimits }) => {
   const { t } = useTranslation('plugin__console-plugin-template');
   const [isAddLimitModalOpen, setIsAddLimitModalOpen] = React.useState(false);
   const [isLimitNameAlertModalOpen, setIsLimitNameAlertModalOpen] = React.useState(false);
-  // State to hold the temporary limit being added
   const [newLimit, setNewLimit] = React.useState<LimitConfig>({
     rates: [{ duration: 60, limit: 100, unit: 'minute' }]
   });
   const [rateName, setRateName] = React.useState<string>('');
+
   const handleOpenModal = () => {
-    // Reset temporary state when opening modal for new entry
     setNewLimit({ rates: [{ duration: 60, limit: 100, unit: 'minute' }] });
     setRateName('');
     setIsAddLimitModalOpen(true);
   };
+
   const handleCloseModal = () => setIsAddLimitModalOpen(false);
 
   const onAddLimit = () => {
     if (!rateName) {
-      // Show alert modal if rateName is empty
       setIsLimitNameAlertModalOpen(true);
       return;
     }
 
-    // Append the new limit to the list of limits
     setLimits((prevLimits) => ({
       ...prevLimits,
       [rateName]: newLimit,
     }));
 
-    // Close the modal after saving
     handleCloseModal();
   };
 
-  // Handle removing a limit by name
   const handleRemoveLimit = (name: string) => {
     setLimits((prevLimits) => {
       const updatedLimits = { ...prevLimits };
@@ -55,29 +51,23 @@ const LimitSelect: React.FC<LimitSelectProps> = ({ limits, setLimits }) => {
   return (
     <>
       <FormGroup>
-        <Title headingLevel="h2" size="lg" style={{ marginTop: '20px' }}>{t('Configured Limits')}</Title>
-        <List>
+        <Title headingLevel="h2" size="lg" className="kuadrant-limits-header">{t('Configured Limits')}</Title>
+        <LabelGroup numLabels={5}>
           {Object.keys(limits).length > 0 ? (
             Object.entries(limits).map(([name, limitConfig], index) => (
-              <ListItem key={index}>
-                <Flex>
-                  <FlexItem>
-                    <strong>{name}</strong>: {limitConfig.rates?.[0]?.limit} requests per {limitConfig.rates?.[0]?.duration} {limitConfig.rates?.[0]?.unit}(s)
-                  </FlexItem>
-                  <FlexItem>
-                    {/* Button to remove a limit */}
-                    <Button variant="danger" onClick={() => handleRemoveLimit(name)}>
-                      {t('Remove Limit')}
-                    </Button>
-                  </FlexItem>
-                </Flex>
-              </ListItem>
+              <Label
+                key={index}
+                color="blue"
+                onClose={() => handleRemoveLimit(name)}
+              >
+                <strong>{name}</strong>: {limitConfig.rates?.[0]?.limit} requests per {limitConfig.rates?.[0]?.duration} {limitConfig.rates?.[0]?.unit}(s)
+              </Label>
             ))
           ) : (
-            <ListItem>{t('No limits configured yet')}</ListItem>
+            <p>{t('No limits configured yet')}</p>
           )}
-        </List>
-        <Button variant="primary" onClick={handleOpenModal}>
+        </LabelGroup>
+        <Button variant="primary" onClick={handleOpenModal} className="kuadrant-limits-button">
           {t('Add Limit')}
         </Button>
       </FormGroup>


### PR DESCRIPTION
Small refactor to move the limit selector pieces fully out to a separate component.
Also uses the [label pattern](https://www.patternfly.org/components/label) from patternfly now.


## Before

*no limits*

<img width="482" alt="image" src="https://github.com/user-attachments/assets/80bcac8c-937f-403b-bd2c-b7ba5fb22914">

*limits added*

<img width="505" alt="image" src="https://github.com/user-attachments/assets/594c2a69-ab97-4344-a959-bea98e914552">


## After

*no limits*

![image](https://github.com/user-attachments/assets/6a758922-a397-429d-91d7-8a5ef2ae7760)

*limits added* 

![image](https://github.com/user-attachments/assets/8482b871-ee84-45fc-8cf7-7535d6b2ef66)
